### PR TITLE
Add library, create template resource ourselves

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,6 +35,7 @@ default[:proxy][:defaults][:srvtimeout]    = 50000
 default[:proxy][:defaults][:stats_uri]     = '/stats'
 default[:proxy][:defaults][:stats_realm]   = 'haproxy'
 default[:proxy][:defaults][:stats_auth]    = 'admin:secret'
+default[:proxy][:defaults][:stats_port]    = 80
  
 default[:proxy][:backend][:interval]       = 2000
 default[:proxy][:backend][:rise]           = 2

--- a/libraries/proxy.rb
+++ b/libraries/proxy.rb
@@ -1,4 +1,21 @@
-# libraries/verifier.rb
+# libraries/proxy.rb
+#
+# Author: Simple Finance <ops@simple.com>
+# License: Apache License, Version 2.0
+#
+# Copyright 2013 Simple Finance Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Performs some basic operations on proxy data bag items
 

--- a/libraries/proxy.rb
+++ b/libraries/proxy.rb
@@ -1,0 +1,28 @@
+# libraries/verifier.rb
+#
+# Performs some basic operations on proxy data bag items
+
+class Simple
+  module Proxy
+    
+    def verify(item)
+      return check_key(item, 'proxy_port') || ip_match?(item) || check_hosts(item)
+    end
+
+    private
+
+    def check_key(item, key)
+      item[key]
+    end
+
+    def check_hosts(item)
+      item['hosts'] || item.fetch(node[:short_environment], {})['hosts']
+    end
+
+    def ip_match?(item)
+      item['proxy_host'] ? node[:ipaddress] == Resolv.getaddress(item['proxy_host']) : true
+    end
+
+  end
+end
+

--- a/libraries/proxy.rb
+++ b/libraries/proxy.rb
@@ -39,7 +39,7 @@ class Simple
     def include_ip?(item)
       ip_addrs = node[:network][:interfaces].collect{|name,i| i['addresses']}.collect{|i| i.keys}.flatten
       ip_addrs.push '*'
-      ip_addrs.include?(item['proxy_ip']) ? true : false
+      ip_addrs.include? item['proxy_ip']
     end
 
   end

--- a/libraries/proxy.rb
+++ b/libraries/proxy.rb
@@ -23,7 +23,7 @@ class Simple
   module Proxy
     
     def verify(item)
-      return check_key(item, 'proxy_port') || ip_match?(item) || check_hosts(item)
+      return check_key(item, 'proxy_port') && include_ip?(item) && check_hosts(item)
     end
 
     private
@@ -36,8 +36,9 @@ class Simple
       item['hosts'] || item.fetch(node[:short_environment], {})['hosts']
     end
 
-    def ip_match?(item)
-      item['proxy_host'] ? node[:ipaddress] == Resolv.getaddress(item['proxy_host']) : true
+    def include_ip?(item)
+      ip_addrs = node[:network][:interfaces].collect{|name,i| i['addresses']}.collect{|i| i.keys}.flatten
+      ip_addrs.include?(item['proxy_ip']) ? true : false
     end
 
   end

--- a/libraries/proxy.rb
+++ b/libraries/proxy.rb
@@ -38,6 +38,7 @@ class Simple
 
     def include_ip?(item)
       ip_addrs = node[:network][:interfaces].collect{|name,i| i['addresses']}.collect{|i| i.keys}.flatten
+      ip_addrs.push '*'
       ip_addrs.include?(item['proxy_ip']) ? true : false
     end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ description           'Sets up instances for proxying traffic'
 maintainer            'Simple Finance'
 maintainer_email      'ops@simple.com'
 license               'Apache 2.0'
-version               '1.0.0'
+version               '1.1.0'
 
 depends 'haproxy'
 

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -29,7 +29,7 @@ include_recipe 'haproxy::default'
 
 proxies = data_bag(node[:proxy][:databag]).sort.collect do |name|
   item = data_bag_item(node[:proxy][:databag], name)
-  item['proxy_ip'] = svc['proxy_host'] ? Resolv.getaddress(svc['proxy_host']) : '*'
+  item['proxy_ip'] = item['proxy_host'] ? Resolv.getaddress(item['proxy_host']) : '*'
   item
 end.select do |svc|
   if !verify(svc)

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -29,11 +29,11 @@ defaults
         errorfile       503     /etc/haproxy/errors/503.http
         errorfile       504     /etc/haproxy/errors/504.http
 
-listen stats *:80
+listen stats *:<%= @defaults[:stats_port] %>
         mode http
 
 <% @services.each do |svc| %>
-frontend <%= svc['id'] %>-frontend <%= svc['proxy_host'] %>:<%= svc['proxy_port'] %>
+frontend <%= svc['id'] %>-frontend <%= svc['proxy_ip'] %>:<%= svc['proxy_port'] %>
         mode tcp
         option tcplog
         default_backend <%= svc['id'] %>-backend


### PR DESCRIPTION
Changes:
- Adds a dinky library to make the recipe cleaner
- Create template resource directly instead of guessing that one exists
- Filtering against IP addresses instead of just `node[:ipaddress]` (in library)
- Use `proxy_ip` key in template instead of blowing away `proxy_host`
