### PR TITLE
[1.2.0] Add monitoring recipe for Sensu integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Configures an instance to route traffic via HAproxy
 Configures an instance to send traffic destined for a host to go through a
 proxy instance via the `node[:proxy][:host]` attribute.
 
+#### Monitoring
+This recipe sets up Sensu checks for each data bag item (and thus, each
+client). This obviously requires Sensu, which we use, but the recipe provides a cheap
+way of shipping monitoring using already-defined data.
+
 ## Resources
 
 #### proxy\_host

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -43,7 +43,7 @@ default[:proxy][:backend][:fall]           = 5
 default[:proxy][:backend][:ssl]            = false
 
 # Never necessary -- use only if you want Sensu check customization!
-default[:proxy][:sensu][:handlers]         = nil
-default[:proxy][:sensu][:check_interval]   = nil
-default[:proxy][:sensu][:occurrences]      = nil
+default[:proxy][:sensu][:handlers]         = ['default']
+default[:proxy][:sensu][:check_interval]   = 15
+default[:proxy][:sensu][:additional]       = { :occurrences => 4 }
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -42,7 +42,6 @@ default[:proxy][:backend][:rise]           = 2
 default[:proxy][:backend][:fall]           = 5
 default[:proxy][:backend][:ssl]            = false
 
-# Never necessary -- use only if you want Sensu check customization!
 default[:proxy][:sensu][:handlers]         = ['default']
 default[:proxy][:sensu][:check_interval]   = 15
 default[:proxy][:sensu][:additional]       = { :occurrences => 4 }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -42,3 +42,8 @@ default[:proxy][:backend][:rise]           = 2
 default[:proxy][:backend][:fall]           = 5
 default[:proxy][:backend][:ssl]            = false
 
+# Never necessary -- use only if you want Sensu check customization!
+default[:proxy][:sensu][:handlers]         = nil
+default[:proxy][:sensu][:check_interval]   = nil
+default[:proxy][:sensu][:occurrences]      = nil
+

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,10 @@ description           'Sets up instances for proxying traffic'
 maintainer            'Simple Finance'
 maintainer_email      'ops@simple.com'
 license               'Apache 2.0'
-version               '1.1.0'
+version               '1.2.0'
 
 depends 'haproxy'
+
+# Necessary for the `monitoring` recipe
+suggests 'sensu'
 

--- a/recipes/monitoring.rb
+++ b/recipes/monitoring.rb
@@ -19,8 +19,6 @@
 #
 # Use Sensu? So do we! Auto check generation
 
-include_recipe 'sensu::server'
-
 # Deploy a sensu_check per HAProxy backend
 data_bag(node[:proxy][:databag]).sort.each do |item|
   client = data_bag_item(node[:proxy][:databag], item)

--- a/recipes/monitoring.rb
+++ b/recipes/monitoring.rb
@@ -1,0 +1,36 @@
+# recipes/monitoring.rb
+#
+# Author: Simple Finance <ops@simple.com>
+# License: Apache License, Version 2.0
+#
+# Copyright 2013 Simple Finance Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Use Sensu? So do we! Auto check generation
+
+# Deploy a sensu_check per HAProxy backend
+data_bag(node[:proxy][:databag]).sort.each do |item|
+  client = data_bag_item(node[:proxy][:databag], item)
+  user, pass = node[:proxy][:defaults][:stats_auth].split(':')
+
+  sensu_check "#{client['id']}-backend" do
+    command "haproxy-backend.rb -b #{client['id']}-backend -u #{user} -p #{pass}"
+    subscribers client['proxy_host'] || node[:proxy][:host]
+    handlers node[:proxy][:sensu][:handlers] || ['default']
+    interval node[:proxy][:sensu][:check_interval] || 15
+    additional(
+      :occurrences => node[:proxy][:sensu][:occurrences] || 4 )
+  end
+end
+


### PR DESCRIPTION
Welp:
- Adds a `monitoring` recipe which will generate a check per HAProxy backend
- Bumps version to 1.2.0

Currently missing the actual Sensu plugin because I haven't sent it upstream yet B-) could also just ship it in here but that sucks I suppose. Not sure if we'd want to put this recipe here -- I think it's acceptable despite being for a different utility, but open to why that is not so.
